### PR TITLE
catch and handle circular references in objects being logged

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -96,7 +96,7 @@ module.exports = (level, ...args) => {
     // keep track of object values, so we know if they occur twice (circular reference)
     let seenValues = []
 
-    var valueChecker = function(objValue) {
+    var valueChecker = function(objKey, objValue) {
       if (objValue !== null && typeof objValue === 'object') {
         if (seenValues.indexOf(objValue) > -1) {
           // let it be logged that there was something sanitized

--- a/src/format.js
+++ b/src/format.js
@@ -87,29 +87,34 @@ module.exports = (level, ...args) => {
     // Wrap truncated output in a string
     return JSON.stringify({ message: 'Truncated ' + truncated })
   } catch (err) {
-    /*
-    we have caught an exception, we assume it is 
-    a circular reference and parse through the 
-    object while keeping track of elements occuring twice
-    */
+    if (err.message === 'Converting circular structure to JSON') {
+      /*
+      it is a circular reference and parse 
+      through the object while keeping track 
+      of elements occuring twice
+      */
 
-    // keep track of object values, so we know if they occur twice (circular reference)
-    let seenValues = []
+      // keep track of object values, so we know if they occur twice (circular reference)
+      let seenValues = []
 
-    var valueChecker = function(objKey, objValue) {
-      if (objValue !== null && typeof objValue === 'object') {
-        if (seenValues.indexOf(objValue) > -1) {
-          // let it be logged that there was something sanitized
-          return '[Circular:StrippedOut]'
-        } else {
-          // track that we have 'seen' it
-          seenValues.push(objValue)
+      var valueChecker = function(objKey, objValue) {
+        if (objValue !== null && typeof objValue === 'object') {
+          if (seenValues.indexOf(objValue) > -1) {
+            // let it be logged that there was something sanitized
+            return '[Circular:StrippedOut]'
+          } else {
+            // track that we have 'seen' it
+            seenValues.push(objValue)
+          }
         }
+        // first time seeing it, return and proceed to next value
+        return objValue
       }
-      // first time seeing it, return and proceed to next value
-      return objValue
-    }
 
-    return JSON.stringify(output, valueChecker)
+      return JSON.stringify(output, valueChecker)
+    } else {
+      // it isn't an error we know how to handle
+      throw err
+    }
   }
 }

--- a/src/format.js
+++ b/src/format.js
@@ -17,66 +17,99 @@ module.exports = (level, ...args) => {
     context: {},
     data: []
   }
-  // Check for arguments
-  if (args.length > 0) {
-    if (args[0] instanceof Array) {
-      // Stringify lists as the message and add as data
-      output.message = args[0].join(', ')
-      output.data = args[0]
-    } else if (args[0] instanceof Object) {
-      // Override logging output for objects (and errors)
-      for (const key of Object.getOwnPropertyNames(args[0])) {
-        output[key] = args[0][key]
-      }
-    } else {
-      // Set primitive types as the message
-      output.message = args[0]
-    }
-    if (args.length > 1) {
-      if (args[1] instanceof Object) {
-        // Set objects as secondary arguments as the context
-        output.context = args[1]
+  /*
+  wrap it all in a try and catch, so if there was an 
+  error we go through just the object that caused an 
+  error, and not over zealously check every objects values
+  */
+
+  try {
+    // Check for arguments
+    if (args.length > 0) {
+      if (args[0] instanceof Array) {
+        // Stringify lists as the message and add as data
+        output.message = args[0].join(', ')
+        output.data = args[0]
+      } else if (args[0] instanceof Object) {
+        // Override logging output for objects (and errors)
+        for (const key of Object.getOwnPropertyNames(args[0])) {
+          output[key] = args[0][key]
+        }
       } else {
-        // Set all other types as data
-        output.data.push(args[1])
+        // Set primitive types as the message
+        output.message = args[0]
+      }
+      if (args.length > 1) {
+        if (args[1] instanceof Object) {
+          // Set objects as secondary arguments as the context
+          output.context = args[1]
+        } else {
+          // Set all other types as data
+          output.data.push(args[1])
+        }
+      }
+      if (args.length > 2) {
+        for (let i = 2; i < args.length; i++) {
+          // Set additional arguments as data
+          output.data.push(args[i])
+        }
       }
     }
-    if (args.length > 2) {
-      for (let i = 2; i < args.length; i++) {
-        // Set additional arguments as data
-        output.data.push(args[i])
+    if (output.message === '') {
+      // Remove empty messages
+      delete output.message
+    }
+    if (Object.keys(output.context).length === 0) {
+      // Remove empty contexts
+      delete output.context
+    }
+    if (output.data.length === 0) {
+      // Remove empty data
+      delete output.data
+    }
+    // Add level
+    output.level = getLogLevelName(level)
+    // Add timestamp
+    output.timestamp = new Date().toISOString()
+    // Stringify output
+    const blob = JSON.stringify(output)
+    // Check for size being less than than 100 KB
+    if (blob.length <= 100 * 1024) {
+      // Check for depth above 10
+      if (depthOf(output) > 10) {
+        // Wrap deep objects in a string
+        return JSON.stringify({ message: 'Depth limited ' + blob })
       }
+      return blob
     }
-  }
-  if (output.message === '') {
-    // Remove empty messages
-    delete output.message
-  }
-  if (Object.keys(output.context).length === 0) {
-    // Remove empty contexts
-    delete output.context
-  }
-  if (output.data.length === 0) {
-    // Remove empty data
-    delete output.data
-  }
-  // Add level
-  output.level = getLogLevelName(level)
-  // Add timestamp
-  output.timestamp = new Date().toISOString()
-  // Stringify output
-  const blob = JSON.stringify(output)
-  // Check for size being less than than 100 KB
-  if (blob.length <= 100 * 1024) {
-    // Check for depth above 10
-    if (depthOf(output) > 10) {
-      // Wrap deep objects in a string
-      return JSON.stringify({ message: 'Depth limited ' + blob })
+    // Truncate stringified output to 100 KB
+    const truncated = blob.substring(0, 100 * 1024)
+    // Wrap truncated output in a string
+    return JSON.stringify({ message: 'Truncated ' + truncated })
+  } catch (err) {
+    /*
+    we have caught an exception, we assume it is 
+    a circular reference and parse through the 
+    object while keeping track of elements occuring twice
+    */
+
+    // keep track of object values, so we know if they occur twice (circular reference)
+    let seenValues = []
+
+    var valueChecker = function(objValue) {
+      if (objValue !== null && typeof objValue === 'object') {
+        if (seenValues.indexOf(objValue) > -1) {
+          // let it be logged that there was something sanitized
+          return '[Circular:StrippedOut]'
+        } else {
+          // track that we have 'seen' it
+          seenValues.push(objValue)
+        }
+      }
+      // first time seeing it, return and proceed to next value
+      return objValue
     }
-    return blob
+
+    return JSON.stringify(output, valueChecker)
   }
-  // Truncate stringified output to 100 KB
-  const truncated = blob.substring(0, 100 * 1024)
-  // Wrap truncated output in a string
-  return JSON.stringify({ message: 'Truncated ' + truncated })
 }

--- a/src/format.test.js
+++ b/src/format.test.js
@@ -232,4 +232,57 @@ describe('src/format', () => {
       '{"normalProperty":"expected value","circular":{"normalProperty":"expected value","circular":"[Circular:StrippedOut]"},"level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
+
+  it('formats a circular object with too deep nesting', () => {
+    var nestedObj = {
+      nested: {
+        nested: {
+          nested: {
+            nested: {
+              nested: {
+                nested: {
+                  nested: {
+                    nested: {
+                      nested: { nested: { nested: { nested: 'value' } } }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    nestedObj.circular = nestedObj
+    expect(
+      format(logLevels.WARN, nestedObj),
+      'to be',
+      '{"message":"Depth limited {\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":\\"value\\"}}}}}}}}}}},\\"circular\\":{\\"nested\\":\\"[Circular:StrippedOut]\\",\\"circular\\":\\"[Circular:StrippedOut]\\"},\\"level\\":\\"WARN\\",\\"timestamp\\":\\"2017-09-01T13:37:42.000Z\\"}"}'
+    )
+  })
+
+  it('formats a circular object with too long a message', () => {
+    let blob = ''
+    for (let i = 0; i < 1024; i++) {
+      blob += 'something!'
+    }
+    let msg = ''
+    for (let i = 0; i < 110; i++) {
+      msg += blob
+    }
+    var obj = {}
+    obj.message = msg
+    obj.circular = obj
+
+    expect(
+      format(logLevels.WARN, obj),
+      'to match',
+      /^\{"message":"Truncated \{\\\"message\\\":\\\"(something!){10200,}somethin"\}$/
+    )
+    expect(
+      format(logLevels.WARN, msg).length,
+      'to be less than or equal to',
+      110 * 1024
+    )
+  })
 })

--- a/src/format.test.js
+++ b/src/format.test.js
@@ -285,4 +285,16 @@ describe('src/format', () => {
       110 * 1024
     )
   })
+
+  it('still throws unknown errors', () => {
+    var sandbox = sinon.sandbox.create()
+
+    sandbox.stub(JSON, 'stringify').throws()
+
+    expect(() => {
+      format(logLevels.WARN, { data: 'fake' })
+    }, 'to throw')
+
+    sandbox.restore()
+  })
 })

--- a/src/format.test.js
+++ b/src/format.test.js
@@ -219,4 +219,17 @@ describe('src/format', () => {
       '{"message":"Depth limited {\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":\\"value\\"}}}}}}}}}}},\\"level\\":\\"WARN\\",\\"timestamp\\":\\"2017-09-01T13:37:42.000Z\\"}"}'
     )
   })
+
+  it('formats an object containing a circular reference', () => {
+    var topLevel = {
+      normalProperty: 'expected value'
+    }
+    topLevel.circular = topLevel
+
+    expect(
+      format(logLevels.WARN, topLevel),
+      'to be',
+      '{"normalProperty":"expected value","circular":{"normalProperty":"expected value","circular":"[Circular:StrippedOut]"},"level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+    )
+  })
 })


### PR DESCRIPTION
It looks like a bigger change than it is, since it's all indented due to wrapping in a try and catch.
closes https://github.com/connectedcars/node-logutil/issues/1