### PR TITLE
Log all metrics in a single json log line

### DIFF
--- a/src/metric.js
+++ b/src/metric.js
@@ -18,9 +18,11 @@ class MetricRegistry {
     return metric
   }
   async logMetrics() {
-    for (let metric of await this.getMetrics()) {
-      statistic(`Metric dump`, this.convertTimestampToIsoString(metric))
-    }
+    const metrics = await this.getMetrics()
+
+    statistic(`Metric dump`, {
+      metrics: metrics.map(this.convertTimestampToIsoString)
+    })
   }
   async getMetrics() {
     let result = []

--- a/src/metric.test.js
+++ b/src/metric.test.js
@@ -161,7 +161,7 @@ describe('src/metric.js', () => {
     await this.metricRegistry.cumulative('cumulative', 20, { brand: 'vw' })
     await this.metricRegistry.logMetrics()
 
-    expect(this.statistic.callCount, 'to be', 2)
+    expect(this.statistic.callCount, 'to be', 1)
     expect(this.statistic.args[0].length, 'to be', 1)
     expect(
       this.statistic.args[0][0],
@@ -169,29 +169,23 @@ describe('src/metric.js', () => {
       JSON.stringify({
         message: 'Metric dump',
         context: {
-          name: 'gauge',
-          type: 'GAUGE',
-          value: 4,
-          labels: { brand: 'vw' },
-          endTime: '2017-09-01T13:37:42.000Z'
-        },
-        level: 'STATISTIC',
-        timestamp: '2017-09-01T13:37:42.000Z'
-      })
-    )
-
-    expect(
-      this.statistic.args[1][0],
-      'to equal',
-      JSON.stringify({
-        message: 'Metric dump',
-        context: {
-          name: 'cumulative',
-          type: 'CUMULATIVE',
-          value: 20,
-          labels: { brand: 'vw' },
-          startTime: '2017-09-01T13:37:42.000Z',
-          endTime: '2017-09-01T13:37:42.000Z'
+          metrics: [
+            {
+              name: 'gauge',
+              type: 'GAUGE',
+              value: 4,
+              labels: { brand: 'vw' },
+              endTime: '2017-09-01T13:37:42.000Z'
+            },
+            {
+              name: 'cumulative',
+              type: 'CUMULATIVE',
+              value: 20,
+              labels: { brand: 'vw' },
+              startTime: '2017-09-01T13:37:42.000Z',
+              endTime: '2017-09-01T13:37:42.000Z'
+            }
+          ]
         },
         level: 'STATISTIC',
         timestamp: '2017-09-01T13:37:42.000Z'


### PR DESCRIPTION
Previously, we've been logging one metrics per line. This ends up
bloating the log a bit. To resolve that, this commit simply puts
all metrics for a given MetricRegistry in one log line.