### PR TITLE
Fix versioning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedcars/logutil",
-  "version": "1.2.5",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedcars/logutil",
-  "version": "1.2.5",
+  "version": "1.1.4",
   "description": "Simple log formatting for Node",
   "main": "src/index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedcars/logutil",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "Simple log formatting for Node",
   "main": "src/index.js",
   "engines": {


### PR DESCRIPTION
It turns out that modifying `package.json` and then calling `npm version` results in an inconsistent state where the `package.json` tag is bumped twice.