### PR TITLE
Support stackdriver logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,21 +189,21 @@ This function is intended to be exposed through a small HTTP server and used in 
 const log = require('logutil')
 
 log.debug('This is a debug message')
-// Outputs to stdout: {"message":"This is a debug message","level":"DEBUG","timestamp":"2017-09-01T13:37:42Z"}
+// Outputs to stdout: {"message":"This is a debug message","severity":"DEBUG","timestamp":"2017-09-01T13:37:42Z"}
 log.debug('This is a statistic value', { foo: 42, bar: 1337 })
-// Outputs to stdout: {"message":"Statistics","level":"STATISTIC","timestamp":"2017-09-01T13:37:42Z", "content":{"foo":42,"bar":1337}}
+// Outputs to stdout: {"message":"Statistics","severity":"STATISTIC","timestamp":"2017-09-01T13:37:42Z", "content":{"foo":42,"bar":1337}}
 log.info('This is an info message')
-// Outputs to stdout: {"message":"This is an info message","level":"INFO","timestamp":"2017-09-01T13:37:42Z"}
+// Outputs to stdout: {"message":"This is an info message","severity":"INFO","timestamp":"2017-09-01T13:37:42Z"}
 log.warn('This is a warning message', { type: 'missing-item' })
-// Outputs to stderr: {"message":"This is a warning message","level":"WARNING","timestamp":"2017-09-01T13:37:42Z","context":{"type":"missing-item"}}
+// Outputs to stderr: {"message":"This is a warning message","severity":"WARNING","timestamp":"2017-09-01T13:37:42Z","context":{"type":"missing-item"}}
 log.error('This is an error message', { context: { items: ['foo', 'bar'] } })
-// Outputs to stderr: {"message":"This is an error message","level":"ERROR","timestamp":"2017-09-01T13:37:42Z","context":{"items":["foo","bar"]}}
+// Outputs to stderr: {"message":"This is an error message","severity":"ERROR","timestamp":"2017-09-01T13:37:42Z","context":{"items":["foo","bar"]}}
 
 log.debug(() => {
   // Only runs if log level is debug
   return Promise.resolve('This is a debug message')
 })
-// Outputs to stdout: {"message":"This is a debug message","level":"DEBUBG","timestamp":"2017-09-01T13:37:42Z"}
+// Outputs to stdout: {"message":"This is a debug message","severity":"DEBUBG","timestamp":"2017-09-01T13:37:42Z"}
 log.info(() => {
   // Only runs if log level is info
   return new Promise(resolve => {
@@ -212,7 +212,7 @@ log.info(() => {
     }, 500)
   })
 })
-// Outputs to stdout (after 500 ms): {"message":"This is an info message","level":"INFO","timestamp":"2017-09-01T13:37:42Z"}
+// Outputs to stdout (after 500 ms): {"message":"This is an info message","severity":"INFO","timestamp":"2017-09-01T13:37:42Z"}
 
 // Instantiate as a singleton
 const registry = log.MetricRegistry()

--- a/src/debug.test.js
+++ b/src/debug.test.js
@@ -31,7 +31,7 @@ describe('src/debug', () => {
     log.debug('something')
     expect(console.log.callCount, 'to be', 1)
     expect(console.log.args[0], 'to equal', [
-      '{"message":"something","level":"DEBUG","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","severity":"DEBUG","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.warn.callCount, 'to be', 0)
     expect(console.error.callCount, 'to be', 0)
@@ -43,7 +43,7 @@ describe('src/debug', () => {
     log.debug()
     expect(console.log.callCount, 'to be', 1)
     expect(console.log.args[0], 'to equal', [
-      '{"level":"DEBUG","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"severity":"DEBUG","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.warn.callCount, 'to be', 0)
     expect(console.error.callCount, 'to be', 0)
@@ -55,7 +55,7 @@ describe('src/debug', () => {
     log.debug('something', 42, { foo: 'bar' })
     expect(console.log.callCount, 'to be', 1)
     expect(console.log.args[0], 'to equal', [
-      '{"message":"something","data":[42,{"foo":"bar"}],"level":"DEBUG","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","data":[42,{"foo":"bar"}],"severity":"DEBUG","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.warn.callCount, 'to be', 0)
     expect(console.error.callCount, 'to be', 0)
@@ -69,13 +69,13 @@ describe('src/debug', () => {
     log.debug({ foo: true })
     expect(console.log.callCount, 'to be', 3)
     expect(console.log.args[0], 'to equal', [
-      '{"message":"something","level":"DEBUG","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","severity":"DEBUG","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.log.args[1], 'to equal', [
-      '{"message":"something else","data":[42],"level":"DEBUG","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something else","data":[42],"severity":"DEBUG","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.log.args[2], 'to equal', [
-      '{"foo":true,"level":"DEBUG","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"foo":true,"severity":"DEBUG","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.warn.callCount, 'to be', 0)
     expect(console.error.callCount, 'to be', 0)
@@ -116,7 +116,7 @@ describe('src/debug', () => {
         expect(stub.callCount, 'to be', 1)
         expect(console.log.callCount, 'to be', 1)
         expect(console.log.args[0], 'to equal', [
-          '{"message":"something","level":"DEBUG","timestamp":"2017-09-01T13:37:42.000Z"}'
+          '{"message":"something","severity":"DEBUG","timestamp":"2017-09-01T13:37:42.000Z"}'
         ])
         expect(console.warn.callCount, 'to be', 0)
         expect(console.error.callCount, 'to be', 0)
@@ -134,7 +134,7 @@ describe('src/debug', () => {
       .then(() => {
         expect(console.log.callCount, 'to be', 1)
         expect(console.log.args[0], 'to equal', [
-          '{"message":"something","level":"DEBUG","timestamp":"2017-09-01T13:37:42.000Z"}'
+          '{"message":"something","severity":"DEBUG","timestamp":"2017-09-01T13:37:42.000Z"}'
         ])
         expect(console.warn.callCount, 'to be', 0)
         expect(console.error.callCount, 'to be', 0)
@@ -157,7 +157,7 @@ describe('src/debug', () => {
         expect(
           console.log.args[0][0],
           'to match',
-          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","level":"DEBUG","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","severity":"DEBUG","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
         )
         expect(console.warn.callCount, 'to be', 0)
         expect(console.error.callCount, 'to be', 0)
@@ -181,7 +181,7 @@ describe('src/debug', () => {
         expect(
           console.log.args[0][0],
           'to match',
-          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","level":"DEBUG","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","severity":"DEBUG","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
         )
         expect(console.warn.callCount, 'to be', 0)
         expect(console.error.callCount, 'to be', 0)

--- a/src/error.test.js
+++ b/src/error.test.js
@@ -25,7 +25,7 @@ describe('src/error', () => {
     expect(console.warn.callCount, 'to be', 0)
     expect(console.error.callCount, 'to be', 1)
     expect(console.error.args[0], 'to equal', [
-      '{"message":"something","level":"ERROR","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","severity":"ERROR","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
   })
   it('logs empty argument', () => {
@@ -34,7 +34,7 @@ describe('src/error', () => {
     expect(console.warn.callCount, 'to be', 0)
     expect(console.error.callCount, 'to be', 1)
     expect(console.error.args[0], 'to equal', [
-      '{"level":"ERROR","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"severity":"ERROR","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
   })
   it('logs multiple arguments', () => {
@@ -44,7 +44,7 @@ describe('src/error', () => {
     expect(console.warn.callCount, 'to be', 0)
     expect(console.error.callCount, 'to be', 1)
     expect(console.error.args[0], 'to equal', [
-      '{"message":"something","data":[42,{"foo":"bar"}],"level":"ERROR","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","data":[42,{"foo":"bar"}],"severity":"ERROR","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
   })
   it('logs multiple times', () => {
@@ -56,13 +56,13 @@ describe('src/error', () => {
     expect(console.warn.callCount, 'to be', 0)
     expect(console.error.callCount, 'to be', 3)
     expect(console.error.args[0], 'to equal', [
-      '{"message":"something","level":"ERROR","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","severity":"ERROR","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.error.args[1], 'to equal', [
-      '{"message":"something else","data":[42],"level":"ERROR","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something else","data":[42],"severity":"ERROR","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.error.args[2], 'to equal', [
-      '{"foo":true,"level":"ERROR","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"foo":true,"severity":"ERROR","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
   })
 
@@ -82,7 +82,7 @@ describe('src/error', () => {
         expect(console.warn.callCount, 'to be', 0)
         expect(console.error.callCount, 'to be', 1)
         expect(console.error.args[0], 'to equal', [
-          '{"message":"something","level":"ERROR","timestamp":"2017-09-01T13:37:42.000Z"}'
+          '{"message":"something","severity":"ERROR","timestamp":"2017-09-01T13:37:42.000Z"}'
         ])
         done()
       })
@@ -97,7 +97,7 @@ describe('src/error', () => {
         expect(console.warn.callCount, 'to be', 0)
         expect(console.error.callCount, 'to be', 1)
         expect(console.error.args[0], 'to equal', [
-          '{"message":"something","level":"ERROR","timestamp":"2017-09-01T13:37:42.000Z"}'
+          '{"message":"something","severity":"ERROR","timestamp":"2017-09-01T13:37:42.000Z"}'
         ])
         done()
       })
@@ -117,7 +117,7 @@ describe('src/error', () => {
         expect(
           console.error.args[0][0],
           'to match',
-          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","level":"ERROR","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","severity":"ERROR","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
         )
         done()
       })
@@ -138,7 +138,7 @@ describe('src/error', () => {
         expect(
           console.error.args[0][0],
           'to match',
-          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","level":"ERROR","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","severity":"ERROR","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
         )
         done()
       })

--- a/src/format.js
+++ b/src/format.js
@@ -112,8 +112,8 @@ const format = (level, ...args) => {
       // Remove empty data
       delete output.data
     }
-    // Add level
-    output.level = getLogLevelName(level)
+    // Add level (Stackdriver support)
+    output.severity = getLogLevelName(level)
     // Add timestamp
     output.timestamp = new Date().toISOString()
     // Stringify output

--- a/src/format.test.js
+++ b/src/format.test.js
@@ -15,42 +15,42 @@ describe('src/format', () => {
     expect(
       format(logLevels.WARN, 'something'),
       'to be',
-      '{"message":"something","level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats number message', () => {
     expect(
       format(logLevels.WARN, 42),
       'to be',
-      '{"message":42,"level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":42,"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats string message with extra params', () => {
     expect(
       format(logLevels.WARN, 'something', 42, 'foo'),
       'to be',
-      '{"message":"something","data":[42,"foo"],"level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","data":[42,"foo"],"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats string message with context param', () => {
     expect(
       format(logLevels.WARN, 'something', { count: 42, val: 'foo' }),
       'to be',
-      '{"message":"something","context":{"count":42,"val":"foo"},"level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","context":{"count":42,"val":"foo"},"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats string message with context and extra params', () => {
     expect(
       format(logLevels.WARN, 'something', { count: 42, val: 'foo' }, 'foo'),
       'to be',
-      '{"message":"something","context":{"count":42,"val":"foo"},"data":["foo"],"level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","context":{"count":42,"val":"foo"},"data":["foo"],"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats single object', () => {
     expect(
       format(logLevels.WARN, { message: 'something', count: 42, val: 'foo' }),
       'to be',
-      '{"message":"something","count":42,"val":"foo","level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","count":42,"val":"foo","severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats single object with extra params', () => {
@@ -62,7 +62,7 @@ describe('src/format', () => {
         'foo'
       ),
       'to be',
-      '{"message":"something","data":[42,"foo"],"count":42,"val":"foo","level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","data":[42,"foo"],"count":42,"val":"foo","severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats single object with context param', () => {
@@ -73,7 +73,7 @@ describe('src/format', () => {
         { count: 21, val: 'bar' }
       ),
       'to be',
-      '{"message":"something","context":{"count":21,"val":"bar"},"count":42,"val":"foo","level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","context":{"count":21,"val":"bar"},"count":42,"val":"foo","severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats single object with context and extra params', () => {
@@ -86,28 +86,28 @@ describe('src/format', () => {
         'John'
       ),
       'to be',
-      '{"message":"something","context":{"count":21,"val":"bar"},"data":[1337,"John"],"count":42,"val":"foo","level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","context":{"count":21,"val":"bar"},"data":[1337,"John"],"count":42,"val":"foo","severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats single array', () => {
     expect(
       format(logLevels.WARN, ['something', 42]),
       'to be',
-      '{"message":"something, 42","data":["something",42],"level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something, 42","data":["something",42],"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats single array with extra params', () => {
     expect(
       format(logLevels.WARN, ['something', 42], 42, 'foo'),
       'to be',
-      '{"message":"something, 42","data":["something",42,42,"foo"],"level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something, 42","data":["something",42,42,"foo"],"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats single array with context param', () => {
     expect(
       format(logLevels.WARN, ['something', 42], { count: 21, val: 'bar' }),
       'to be',
-      '{"message":"something, 42","context":{"count":21,"val":"bar"},"data":["something",42],"level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something, 42","context":{"count":21,"val":"bar"},"data":["something",42],"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats single array with context and extra params', () => {
@@ -120,28 +120,28 @@ describe('src/format', () => {
         'John'
       ),
       'to be',
-      '{"message":"something, 42","context":{"count":21,"val":"bar"},"data":["something",42,1337,"John"],"level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something, 42","context":{"count":21,"val":"bar"},"data":["something",42,1337,"John"],"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats error object', () => {
     expect(
       format(logLevels.WARN, new Error('something')),
       'to match',
-      /^\{"message":"something","stack":"Error: something\\n(.+?)","level":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+      /^\{"message":"something","stack":"Error: something\\n(.+?)","severity":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
     )
   })
   it('formats error object with extra params', () => {
     expect(
       format(logLevels.WARN, new Error('something'), 42, 'foo'),
       'to match',
-      /^\{"message":"something","data":\[42,"foo"\],"stack":"Error: something\\n(.+?)","level":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+      /^\{"message":"something","data":\[42,"foo"\],"stack":"Error: something\\n(.+?)","severity":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
     )
   })
   it('formats error object with context param', () => {
     expect(
       format(logLevels.WARN, new Error('something'), { count: 21, val: 'bar' }),
       'to match',
-      /^\{"message":"something","context":\{"count":21,"val":"bar"\},"stack":"Error: something\\n(.+?)","level":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+      /^\{"message":"something","context":\{"count":21,"val":"bar"\},"stack":"Error: something\\n(.+?)","severity":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
     )
   })
   it('formats error object with context and extra params', () => {
@@ -154,7 +154,7 @@ describe('src/format', () => {
         'John'
       ),
       'to match',
-      /^\{"message":"something","context":\{"count":21,"val":"bar"\},"data":\[1337,"John"\],"stack":"Error: something\\n(.+?)","level":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+      /^\{"message":"something","context":\{"count":21,"val":"bar"\},"data":\[1337,"John"\],"stack":"Error: something\\n(.+?)","severity":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
     )
   })
   it('formats context which includes error object', () => {
@@ -164,7 +164,7 @@ describe('src/format', () => {
         e: new Error('some err')
       }),
       'to match',
-      /^\{"message":"something","context":\{"MyContext":1,"e":\{"stack":"Error: some err\\n(.+?)","message":"some err","__constructorName":"Error"\}\},"level":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+      /^\{"message":"something","context":\{"MyContext":1,"e":\{"stack":"Error: some err\\n(.+?)","message":"some err","__constructorName":"Error"\}\},"severity":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
     )
   })
   it('formats very large message', () => {
@@ -201,7 +201,7 @@ describe('src/format', () => {
         }
       }),
       'to be',
-      '{"nested":{"nested":{"nested":{"nested":{"nested":{"nested":{"nested":{"nested":{"nested":"value"}}}}}}}},"level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"nested":{"nested":{"nested":{"nested":{"nested":{"nested":{"nested":{"nested":{"nested":"value"}}}}}}}},"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats too deep object', () => {
@@ -226,7 +226,7 @@ describe('src/format', () => {
         }
       }),
       'to be',
-      '{"message":"Depth limited {\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":\\"value\\"}}}}}}}}}}},\\"level\\":\\"WARN\\",\\"timestamp\\":\\"2017-09-01T13:37:42.000Z\\"}"}'
+      '{"message":"Depth limited {\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":\\"value\\"}}}}}}}}}}},\\"severity\\":\\"WARN\\",\\"timestamp\\":\\"2017-09-01T13:37:42.000Z\\"}"}'
     )
   })
 
@@ -239,7 +239,7 @@ describe('src/format', () => {
     expect(
       format(logLevels.WARN, topLevel),
       'to be',
-      '{"normalProperty":"expected value","circular":{"normalProperty":"expected value","circular":"[Circular:StrippedOut]"},"level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"normalProperty":"expected value","circular":{"normalProperty":"expected value","circular":"[Circular:StrippedOut]"},"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
 
@@ -267,7 +267,7 @@ describe('src/format', () => {
     expect(
       format(logLevels.WARN, nestedObj),
       'to be',
-      '{"message":"Depth limited {\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":\\"value\\"}}}}}}}}}}},\\"circular\\":{\\"nested\\":\\"[Circular:StrippedOut]\\",\\"circular\\":\\"[Circular:StrippedOut]\\"},\\"level\\":\\"WARN\\",\\"timestamp\\":\\"2017-09-01T13:37:42.000Z\\"}"}'
+      '{"message":"Depth limited {\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":\\"value\\"}}}}}}}}}}},\\"circular\\":{\\"nested\\":\\"[Circular:StrippedOut]\\",\\"circular\\":\\"[Circular:StrippedOut]\\"},\\"severity\\":\\"WARN\\",\\"timestamp\\":\\"2017-09-01T13:37:42.000Z\\"}"}'
     )
   })
 
@@ -377,7 +377,7 @@ describe('src/format', () => {
           WHERE (userId = :userId) ''}
         ) AS count2
     `
-    const expectedLogOutput = `{"message":"\\n      SELECT\\n        ( SELECT COUNT(*) FROM messages\\n          WHERE (senderId = :userId OR receiverId = :userId) AND workshopId = :workshopId\\n        ) AS count1,\\n\\n        ( SELECT COUNT(*) FROM UserActivities\\n          WHERE (userId = :userId) ''}\\n        ) AS count2\\n    ","level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}`
+    const expectedLogOutput = `{"message":"\\n      SELECT\\n        ( SELECT COUNT(*) FROM messages\\n          WHERE (senderId = :userId OR receiverId = :userId) AND workshopId = :workshopId\\n        ) AS count1,\\n\\n        ( SELECT COUNT(*) FROM UserActivities\\n          WHERE (userId = :userId) ''}\\n        ) AS count2\\n    ","severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}`
 
     expect(format(logLevels.WARN, countQuery), 'to be', expectedLogOutput)
   })

--- a/src/info.test.js
+++ b/src/info.test.js
@@ -31,7 +31,7 @@ describe('src/info', () => {
     log.info('something')
     expect(console.log.callCount, 'to be', 1)
     expect(console.log.args[0], 'to equal', [
-      '{"message":"something","level":"INFO","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","severity":"INFO","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.warn.callCount, 'to be', 0)
     expect(console.error.callCount, 'to be', 0)
@@ -43,7 +43,7 @@ describe('src/info', () => {
     log.info()
     expect(console.log.callCount, 'to be', 1)
     expect(console.log.args[0], 'to equal', [
-      '{"level":"INFO","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"severity":"INFO","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.warn.callCount, 'to be', 0)
     expect(console.error.callCount, 'to be', 0)
@@ -55,7 +55,7 @@ describe('src/info', () => {
     log.info('something', 42, { foo: 'bar' })
     expect(console.log.callCount, 'to be', 1)
     expect(console.log.args[0], 'to equal', [
-      '{"message":"something","data":[42,{"foo":"bar"}],"level":"INFO","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","data":[42,{"foo":"bar"}],"severity":"INFO","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.warn.callCount, 'to be', 0)
     expect(console.error.callCount, 'to be', 0)
@@ -69,13 +69,13 @@ describe('src/info', () => {
     log.info({ foo: true })
     expect(console.log.callCount, 'to be', 3)
     expect(console.log.args[0], 'to equal', [
-      '{"message":"something","level":"INFO","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","severity":"INFO","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.log.args[1], 'to equal', [
-      '{"message":"something else","data":[42],"level":"INFO","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something else","data":[42],"severity":"INFO","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.log.args[2], 'to equal', [
-      '{"foo":true,"level":"INFO","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"foo":true,"severity":"INFO","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.warn.callCount, 'to be', 0)
     expect(console.error.callCount, 'to be', 0)
@@ -116,7 +116,7 @@ describe('src/info', () => {
         expect(stub.callCount, 'to be', 1)
         expect(console.log.callCount, 'to be', 1)
         expect(console.log.args[0], 'to equal', [
-          '{"message":"something","level":"INFO","timestamp":"2017-09-01T13:37:42.000Z"}'
+          '{"message":"something","severity":"INFO","timestamp":"2017-09-01T13:37:42.000Z"}'
         ])
         expect(console.warn.callCount, 'to be', 0)
         expect(console.error.callCount, 'to be', 0)
@@ -134,7 +134,7 @@ describe('src/info', () => {
       .then(() => {
         expect(console.log.callCount, 'to be', 1)
         expect(console.log.args[0], 'to equal', [
-          '{"message":"something","level":"INFO","timestamp":"2017-09-01T13:37:42.000Z"}'
+          '{"message":"something","severity":"INFO","timestamp":"2017-09-01T13:37:42.000Z"}'
         ])
         expect(console.warn.callCount, 'to be', 0)
         expect(console.error.callCount, 'to be', 0)
@@ -157,7 +157,7 @@ describe('src/info', () => {
         expect(
           console.log.args[0][0],
           'to match',
-          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","level":"INFO","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","severity":"INFO","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
         )
         expect(console.warn.callCount, 'to be', 0)
         expect(console.error.callCount, 'to be', 0)
@@ -181,7 +181,7 @@ describe('src/info', () => {
         expect(
           console.log.args[0][0],
           'to match',
-          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","level":"INFO","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","severity":"INFO","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
         )
         expect(console.warn.callCount, 'to be', 0)
         expect(console.error.callCount, 'to be', 0)

--- a/src/metric.test.js
+++ b/src/metric.test.js
@@ -187,7 +187,7 @@ describe('src/metric.js', () => {
             }
           ]
         },
-        level: 'STATISTIC',
+        severity: 'STATISTIC',
         timestamp: '2017-09-01T13:37:42.000Z'
       })
     )

--- a/src/statistic.test.js
+++ b/src/statistic.test.js
@@ -31,7 +31,7 @@ describe('src/statistic', () => {
     log.statistic('something')
     expect(console.log.callCount, 'to be', 1)
     expect(console.log.args[0], 'to equal', [
-      '{"message":"something","level":"STATISTIC","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","severity":"STATISTIC","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.warn.callCount, 'to be', 0)
     expect(console.error.callCount, 'to be', 0)
@@ -43,7 +43,7 @@ describe('src/statistic', () => {
     log.statistic()
     expect(console.log.callCount, 'to be', 1)
     expect(console.log.args[0], 'to equal', [
-      '{"level":"STATISTIC","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"severity":"STATISTIC","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.warn.callCount, 'to be', 0)
     expect(console.error.callCount, 'to be', 0)
@@ -55,7 +55,7 @@ describe('src/statistic', () => {
     log.statistic('something', 42, { foo: 'bar' })
     expect(console.log.callCount, 'to be', 1)
     expect(console.log.args[0], 'to equal', [
-      '{"message":"something","data":[42,{"foo":"bar"}],"level":"STATISTIC","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","data":[42,{"foo":"bar"}],"severity":"STATISTIC","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.warn.callCount, 'to be', 0)
     expect(console.error.callCount, 'to be', 0)
@@ -69,13 +69,13 @@ describe('src/statistic', () => {
     log.statistic({ foo: true })
     expect(console.log.callCount, 'to be', 3)
     expect(console.log.args[0], 'to equal', [
-      '{"message":"something","level":"STATISTIC","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","severity":"STATISTIC","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.log.args[1], 'to equal', [
-      '{"message":"something else","data":[42],"level":"STATISTIC","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something else","data":[42],"severity":"STATISTIC","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.log.args[2], 'to equal', [
-      '{"foo":true,"level":"STATISTIC","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"foo":true,"severity":"STATISTIC","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.warn.callCount, 'to be', 0)
     expect(console.error.callCount, 'to be', 0)
@@ -116,7 +116,7 @@ describe('src/statistic', () => {
         expect(stub.callCount, 'to be', 1)
         expect(console.log.callCount, 'to be', 1)
         expect(console.log.args[0], 'to equal', [
-          '{"message":"something","level":"STATISTIC","timestamp":"2017-09-01T13:37:42.000Z"}'
+          '{"message":"something","severity":"STATISTIC","timestamp":"2017-09-01T13:37:42.000Z"}'
         ])
         expect(console.warn.callCount, 'to be', 0)
         expect(console.error.callCount, 'to be', 0)
@@ -134,7 +134,7 @@ describe('src/statistic', () => {
       .then(() => {
         expect(console.log.callCount, 'to be', 1)
         expect(console.log.args[0], 'to equal', [
-          '{"message":"something","level":"STATISTIC","timestamp":"2017-09-01T13:37:42.000Z"}'
+          '{"message":"something","severity":"STATISTIC","timestamp":"2017-09-01T13:37:42.000Z"}'
         ])
         expect(console.warn.callCount, 'to be', 0)
         expect(console.error.callCount, 'to be', 0)
@@ -157,7 +157,7 @@ describe('src/statistic', () => {
         expect(
           console.log.args[0][0],
           'to match',
-          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","level":"STATISTIC","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","severity":"STATISTIC","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
         )
         expect(console.warn.callCount, 'to be', 0)
         expect(console.error.callCount, 'to be', 0)
@@ -181,7 +181,7 @@ describe('src/statistic', () => {
         expect(
           console.log.args[0][0],
           'to match',
-          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","level":"STATISTIC","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","severity":"STATISTIC","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
         )
         expect(console.warn.callCount, 'to be', 0)
         expect(console.error.callCount, 'to be', 0)

--- a/src/warn.test.js
+++ b/src/warn.test.js
@@ -31,7 +31,7 @@ describe('src/warn', () => {
     expect(console.log.callCount, 'to be', 0)
     expect(console.warn.callCount, 'to be', 1)
     expect(console.warn.args[0], 'to equal', [
-      '{"message":"something","level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.error.callCount, 'to be', 0)
   })
@@ -40,7 +40,7 @@ describe('src/warn', () => {
     expect(console.log.callCount, 'to be', 0)
     expect(console.warn.callCount, 'to be', 1)
     expect(console.warn.args[0], 'to equal', [
-      '{"level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.error.callCount, 'to be', 0)
   })
@@ -50,7 +50,7 @@ describe('src/warn', () => {
     expect(console.log.callCount, 'to be', 0)
     expect(console.warn.callCount, 'to be', 1)
     expect(console.warn.args[0], 'to equal', [
-      '{"message":"something","data":[42,{"foo":"bar"}],"level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","data":[42,{"foo":"bar"}],"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.error.callCount, 'to be', 0)
   })
@@ -62,13 +62,13 @@ describe('src/warn', () => {
     expect(console.log.callCount, 'to be', 0)
     expect(console.warn.callCount, 'to be', 3)
     expect(console.warn.args[0], 'to equal', [
-      '{"message":"something","level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.warn.args[1], 'to equal', [
-      '{"message":"something else","data":[42],"level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something else","data":[42],"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.warn.args[2], 'to equal', [
-      '{"foo":true,"level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"foo":true,"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.error.callCount, 'to be', 0)
   })
@@ -106,7 +106,7 @@ describe('src/warn', () => {
         expect(console.log.callCount, 'to be', 0)
         expect(console.warn.callCount, 'to be', 1)
         expect(console.warn.args[0], 'to equal', [
-          '{"message":"something","level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+          '{"message":"something","severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
         ])
         expect(console.error.callCount, 'to be', 0)
         done()
@@ -121,7 +121,7 @@ describe('src/warn', () => {
         expect(console.log.callCount, 'to be', 0)
         expect(console.warn.callCount, 'to be', 1)
         expect(console.warn.args[0], 'to equal', [
-          '{"message":"something","level":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+          '{"message":"something","severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
         ])
         expect(console.error.callCount, 'to be', 0)
         done()
@@ -141,7 +141,7 @@ describe('src/warn', () => {
         expect(
           console.warn.args[0][0],
           'to match',
-          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","level":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","severity":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
         )
         expect(console.error.callCount, 'to be', 0)
         done()
@@ -162,7 +162,7 @@ describe('src/warn', () => {
         expect(
           console.warn.args[0][0],
           'to match',
-          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","level":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","severity":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
         )
         expect(console.error.callCount, 'to be', 0)
         done()


### PR DESCRIPTION
Turns out that Google's fluentd agent looks for a 'severity' field. If not present, it'll classify things into either `INFO` or `ERROR` depending on the standard stream. `INFO` when log is read from stdout and `ERROR` if log is read from stderr.

Please note that this introduces is a breaking change as I'm also removing the existing property `level`.