### PR TITLE
Fix to message truncation

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -118,6 +118,7 @@ const format = (level, ...args) => {
     // Add timestamp
     output.timestamp = new Date().toISOString()
     // Ensure that message size is no more than half the total allowed size for the blob
+    // This is to truncate very large sql statements
     if (output.message && output.message.length > MAX_TEXT_LENGTH / 2) {
       output.message = `Truncated: ${output.message.substring(
         0,

--- a/src/format.test.js
+++ b/src/format.test.js
@@ -179,7 +179,7 @@ describe('src/format', () => {
     expect(
       format(logLevels.WARN, msg),
       'to match',
-      /^\{"message":"Truncated \{\\\"message\\\":\\\"(something!){10200,}somethin"\}$/
+      /^{"message":"Truncated: (something!){5000,}\.{3}"\,\"severity\"\:\"WARN\",\"timestamp\"\:\"2017-09-01T13:37:42\.000Z\"}$/
     )
     expect(
       format(logLevels.WARN, msg).length,
@@ -284,11 +284,7 @@ describe('src/format', () => {
     obj.message = msg
     obj.circular = obj
 
-    expect(
-      format(logLevels.WARN, obj),
-      'to match',
-      /^\{"message":"Truncated \{\\\"message\\\":\\\"(something!){10200,}somethin"\}$/
-    )
+    expect(format(logLevels.WARN, obj), 'to match', /^.*Truncated.*circular.*$/)
     expect(
       format(logLevels.WARN, msg).length,
       'to be less than or equal to',

--- a/src/format.test.js
+++ b/src/format.test.js
@@ -187,6 +187,26 @@ describe('src/format', () => {
       110 * 1024
     )
   })
+  it('formats very large data', () => {
+    let blob = ''
+    for (let i = 0; i < 1024; i++) {
+      blob += 'something!'
+    }
+    let data = ''
+    for (let i = 0; i < 110; i++) {
+      data += blob
+    }
+    expect(
+      format(logLevels.WARN, 'hello', data),
+      'to match',
+      /^\{"message":"Truncated \{\\\"message\\\":\\\"hello\\\",\\\"data\\\":\[\\\"(something!){5000,}so.*$/
+    )
+    expect(
+      format(logLevels.WARN, 'hello', data).length,
+      'to be less than or equal to',
+      110 * 1024
+    )
+  })
   it('formats not too deep object', () => {
     expect(
       format(logLevels.WARN, {


### PR DESCRIPTION
Truncates the log message, so that the entire json blob is unlikely to be truncated. This is done so stackdriver can parse the json blob and read the severity correctly.

We have can do smarter truncating, such that the blob is never truncated, but only the inner properties, but this requires more work.