### PR TITLE
Add critical, fix warn, keep logLevels

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,24 @@ Type: `object`
 
 Object hash to provide log context.
 
+### log.critical(message[, context])
+
+Logs the provided `message` with the optional `context` as a JSON string, if the log level is set to output critical.
+
+The method takes most input, but the combination described above is the recommended one.
+
+#### message
+
+Type: `string`
+
+Descriptive log message
+
+#### context
+
+Type: `object`
+
+Object hash to provide log context.
+
 ## log.MetricRegistry()
 A singleton instance that holds the state of all metrics in the application at a given point in time. The class should be instantiated globally and kept through the process lifetime.
 
@@ -198,6 +216,8 @@ log.warn('This is a warning message', { type: 'missing-item' })
 // Outputs to stderr: {"message":"This is a warning message","severity":"WARNING","timestamp":"2017-09-01T13:37:42Z","context":{"type":"missing-item"}}
 log.error('This is an error message', { context: { items: ['foo', 'bar'] } })
 // Outputs to stderr: {"message":"This is an error message","severity":"ERROR","timestamp":"2017-09-01T13:37:42Z","context":{"items":["foo","bar"]}}
+log.critical('This is a critical message', { context: { items: ['foo', 'bar'] } })
+// Outputs to stderr: {"message":"This is a critical message","severity":"CRITICAL","timestamp":"2017-09-01T13:37:42Z","context":{"items":["foo","bar"]}}
 
 log.debug(() => {
   // Only runs if log level is debug
@@ -230,4 +250,4 @@ setInterval(registry.logMetrics, 30000)
 
 ## Configuration
 
-Determining what to output depends on the environment variable `LOG_LEVEL`. This variable can be `DEBUG`, `INFO`, `WARN`, or `ERROR`, but defaults to `WARN`.
+Determining what to output depends on the environment variable `LOG_LEVEL`. This variable can be `DEBUG`, `STATISTIC`, `INFO`, `WARN`, `ERROR`, or `CRITICAL` but defaults to `WARN`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1627,9 +1627,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.flattendeep": {

--- a/src/critical.js
+++ b/src/critical.js
@@ -2,5 +2,5 @@ const { logLevels } = require('./levels')
 const log = require('./log')
 
 module.exports = (...args) => {
-  return log(logLevels.WARNING, ...args)
+  return log(logLevels.CRITICAL, ...args)
 }

--- a/src/critical.test.js
+++ b/src/critical.test.js
@@ -1,0 +1,146 @@
+const expect = require('unexpected')
+const sinon = require('sinon')
+const log = require('./index')
+
+describe('src/critical', () => {
+  beforeEach(() => {
+    this.oldLogLevel = process.env.LOG_LEVEL
+    delete process.env.LOG_LEVEL
+    this.clock = sinon.useFakeTimers(Date.parse('2017-09-01T13:37:42Z'))
+    sinon.spy(console, 'log')
+    sinon.spy(console, 'warn')
+    sinon.stub(console, 'error')
+  })
+  afterEach(() => {
+    process.env.LOG_LEVEL = this.oldLogLevel
+    this.clock.restore()
+    console.log.restore()
+    console.warn.restore()
+    console.error.restore()
+  })
+
+  it('logs single argument', () => {
+    log.critical('something')
+    expect(console.log.callCount, 'to be', 0)
+    expect(console.warn.callCount, 'to be', 0)
+    expect(console.error.callCount, 'to be', 1)
+    expect(console.error.args[0], 'to equal', [
+      '{"message":"something","severity":"CRITICAL","timestamp":"2017-09-01T13:37:42.000Z"}'
+    ])
+  })
+  it('logs empty argument', () => {
+    log.critical()
+    expect(console.log.callCount, 'to be', 0)
+    expect(console.warn.callCount, 'to be', 0)
+    expect(console.error.callCount, 'to be', 1)
+    expect(console.error.args[0], 'to equal', [
+      '{"severity":"CRITICAL","timestamp":"2017-09-01T13:37:42.000Z"}'
+    ])
+  })
+  it('logs multiple arguments', () => {
+    process.env.LOG_LEVEL = 'INFO'
+    log.critical('something', 42, { foo: 'bar' })
+    expect(console.log.callCount, 'to be', 0)
+    expect(console.warn.callCount, 'to be', 0)
+    expect(console.error.callCount, 'to be', 1)
+    expect(console.error.args[0], 'to equal', [
+      '{"message":"something","data":[42,{"foo":"bar"}],"severity":"CRITICAL","timestamp":"2017-09-01T13:37:42.000Z"}'
+    ])
+  })
+  it('logs multiple times', () => {
+    process.env.LOG_LEVEL = 'DEBUG'
+    log.critical('something')
+    log.critical('something else', 42)
+    log.critical({ foo: true })
+    expect(console.log.callCount, 'to be', 0)
+    expect(console.warn.callCount, 'to be', 0)
+    expect(console.error.callCount, 'to be', 3)
+    expect(console.error.args[0], 'to equal', [
+      '{"message":"something","severity":"CRITICAL","timestamp":"2017-09-01T13:37:42.000Z"}'
+    ])
+    expect(console.error.args[1], 'to equal', [
+      '{"message":"something else","data":[42],"severity":"CRITICAL","timestamp":"2017-09-01T13:37:42.000Z"}'
+    ])
+    expect(console.error.args[2], 'to equal', [
+      '{"foo":true,"severity":"CRITICAL","timestamp":"2017-09-01T13:37:42.000Z"}'
+    ])
+  })
+
+  it('logs single argument via promise', done => {
+    process.env.LOG_LEVEL = 'WARN'
+    const stub = sinon.stub()
+    log
+      .critical(() => {
+        return new Promise(resolve => {
+          stub()
+          resolve('something')
+        })
+      })
+      .then(() => {
+        expect(stub.callCount, 'to be', 1)
+        expect(console.log.callCount, 'to be', 0)
+        expect(console.warn.callCount, 'to be', 0)
+        expect(console.error.callCount, 'to be', 1)
+        expect(console.error.args[0], 'to equal', [
+          '{"message":"something","severity":"CRITICAL","timestamp":"2017-09-01T13:37:42.000Z"}'
+        ])
+        done()
+      })
+  })
+  it('logs single argument via function', done => {
+    log
+      .critical(() => {
+        return 'something'
+      })
+      .then(() => {
+        expect(console.log.callCount, 'to be', 0)
+        expect(console.warn.callCount, 'to be', 0)
+        expect(console.error.callCount, 'to be', 1)
+        expect(console.error.args[0], 'to equal', [
+          '{"message":"something","severity":"CRITICAL","timestamp":"2017-09-01T13:37:42.000Z"}'
+        ])
+        done()
+      })
+  })
+  it('logs single argument via failing promise', done => {
+    log
+      .critical(() => {
+        return new Promise((resolve, reject) => {
+          reject(new Error('wrah'))
+        })
+      })
+      .then(() => {
+        expect(console.log.callCount, 'to be', 0)
+        expect(console.warn.callCount, 'to be', 0)
+        expect(console.error.callCount, 'to be', 1)
+        expect(console.error.args[0], 'to have length', 1)
+        expect(
+          console.error.args[0][0],
+          'to match',
+          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","severity":"CRITICAL","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+        )
+        done()
+      })
+  })
+  it('logs single argument via exceptional function', done => {
+    log
+      .critical(() => {
+        throw new Error('wrah')
+        return new Promise(resolve => {
+          resolve('something')
+        })
+      })
+      .then(() => {
+        expect(console.log.callCount, 'to be', 0)
+        expect(console.warn.callCount, 'to be', 0)
+        expect(console.error.callCount, 'to be', 1)
+        expect(console.error.args[0], 'to have length', 1)
+        expect(
+          console.error.args[0][0],
+          'to match',
+          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","severity":"CRITICAL","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+        )
+        done()
+      })
+  })
+})

--- a/src/critical.test.js
+++ b/src/critical.test.js
@@ -13,10 +13,7 @@ describe('src/critical', () => {
   })
   afterEach(() => {
     process.env.LOG_LEVEL = this.oldLogLevel
-    this.clock.restore()
-    console.log.restore()
-    console.warn.restore()
-    console.error.restore()
+    sinon.restore()
   })
 
   it('logs single argument', () => {

--- a/src/debug.test.js
+++ b/src/debug.test.js
@@ -12,9 +12,7 @@ describe('src/debug', () => {
   })
   afterEach(() => {
     process.env.LOG_LEVEL = this.oldLogLevel
-    this.clock.restore()
-    console.warn.restore()
-    console.error.restore()
+    sinon.restore()
   })
 
   it('logs nothing', () => {

--- a/src/error.test.js
+++ b/src/error.test.js
@@ -14,9 +14,7 @@ describe('src/error', () => {
   afterEach(() => {
     process.env.LOG_LEVEL = this.oldLogLevel
     this.clock.restore()
-    console.log.restore()
-    console.warn.restore()
-    console.error.restore()
+    sinon.restore()
   })
 
   it('logs single argument', () => {

--- a/src/format.test.js
+++ b/src/format.test.js
@@ -8,7 +8,7 @@ describe('src/format', () => {
     this.clock = sinon.useFakeTimers(Date.parse('2017-09-01T13:37:42Z'))
   })
   afterEach(() => {
-    this.clock.restore()
+    sinon.restore()
   })
 
   it('formats string message', () => {

--- a/src/format.test.js
+++ b/src/format.test.js
@@ -13,158 +13,165 @@ describe('src/format', () => {
 
   it('formats string message', () => {
     expect(
-      format(logLevels.WARN, 'something'),
+      format(logLevels.WARNING, 'something'),
       'to be',
-      '{"message":"something","severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats number message', () => {
     expect(
-      format(logLevels.WARN, 42),
+      format(logLevels.WARNING, 42),
       'to be',
-      '{"message":42,"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":42,"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats string message with extra params', () => {
     expect(
-      format(logLevels.WARN, 'something', 42, 'foo'),
+      format(logLevels.WARNING, 'something', 42, 'foo'),
       'to be',
-      '{"message":"something","data":[42,"foo"],"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","data":[42,"foo"],"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats string message with context param', () => {
     expect(
-      format(logLevels.WARN, 'something', { count: 42, val: 'foo' }),
+      format(logLevels.WARNING, 'something', { count: 42, val: 'foo' }),
       'to be',
-      '{"message":"something","context":{"count":42,"val":"foo"},"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","context":{"count":42,"val":"foo"},"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats string message with context and extra params', () => {
     expect(
-      format(logLevels.WARN, 'something', { count: 42, val: 'foo' }, 'foo'),
+      format(logLevels.WARNING, 'something', { count: 42, val: 'foo' }, 'foo'),
       'to be',
-      '{"message":"something","context":{"count":42,"val":"foo"},"data":["foo"],"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","context":{"count":42,"val":"foo"},"data":["foo"],"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats single object', () => {
     expect(
-      format(logLevels.WARN, { message: 'something', count: 42, val: 'foo' }),
+      format(logLevels.WARNING, {
+        message: 'something',
+        count: 42,
+        val: 'foo'
+      }),
       'to be',
-      '{"message":"something","count":42,"val":"foo","severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","count":42,"val":"foo","severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats single object with extra params', () => {
     expect(
       format(
-        logLevels.WARN,
+        logLevels.WARNING,
         { message: 'something', count: 42, val: 'foo' },
         42,
         'foo'
       ),
       'to be',
-      '{"message":"something","data":[42,"foo"],"count":42,"val":"foo","severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","data":[42,"foo"],"count":42,"val":"foo","severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats single object with context param', () => {
     expect(
       format(
-        logLevels.WARN,
+        logLevels.WARNING,
         { message: 'something', count: 42, val: 'foo' },
         { count: 21, val: 'bar' }
       ),
       'to be',
-      '{"message":"something","context":{"count":21,"val":"bar"},"count":42,"val":"foo","severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","context":{"count":21,"val":"bar"},"count":42,"val":"foo","severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats single object with context and extra params', () => {
     expect(
       format(
-        logLevels.WARN,
+        logLevels.WARNING,
         { message: 'something', count: 42, val: 'foo' },
         { count: 21, val: 'bar' },
         1337,
         'John'
       ),
       'to be',
-      '{"message":"something","context":{"count":21,"val":"bar"},"data":[1337,"John"],"count":42,"val":"foo","severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","context":{"count":21,"val":"bar"},"data":[1337,"John"],"count":42,"val":"foo","severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats single array', () => {
     expect(
-      format(logLevels.WARN, ['something', 42]),
+      format(logLevels.WARNING, ['something', 42]),
       'to be',
-      '{"message":"something, 42","data":["something",42],"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something, 42","data":["something",42],"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats single array with extra params', () => {
     expect(
-      format(logLevels.WARN, ['something', 42], 42, 'foo'),
+      format(logLevels.WARNING, ['something', 42], 42, 'foo'),
       'to be',
-      '{"message":"something, 42","data":["something",42,42,"foo"],"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something, 42","data":["something",42,42,"foo"],"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats single array with context param', () => {
     expect(
-      format(logLevels.WARN, ['something', 42], { count: 21, val: 'bar' }),
+      format(logLevels.WARNING, ['something', 42], { count: 21, val: 'bar' }),
       'to be',
-      '{"message":"something, 42","context":{"count":21,"val":"bar"},"data":["something",42],"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something, 42","context":{"count":21,"val":"bar"},"data":["something",42],"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats single array with context and extra params', () => {
     expect(
       format(
-        logLevels.WARN,
+        logLevels.WARNING,
         ['something', 42],
         { count: 21, val: 'bar' },
         1337,
         'John'
       ),
       'to be',
-      '{"message":"something, 42","context":{"count":21,"val":"bar"},"data":["something",42,1337,"John"],"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something, 42","context":{"count":21,"val":"bar"},"data":["something",42,1337,"John"],"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats error object', () => {
     expect(
-      format(logLevels.WARN, new Error('something')),
+      format(logLevels.WARNING, new Error('something')),
       'to match',
-      /^\{"message":"something","stack":"Error: something\\n(.+?)","severity":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+      /^\{"message":"something","stack":"Error: something\\n(.+?)","severity":"WARNING","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
     )
   })
   it('formats error object with extra params', () => {
     expect(
-      format(logLevels.WARN, new Error('something'), 42, 'foo'),
+      format(logLevels.WARNING, new Error('something'), 42, 'foo'),
       'to match',
-      /^\{"message":"something","data":\[42,"foo"\],"stack":"Error: something\\n(.+?)","severity":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+      /^\{"message":"something","data":\[42,"foo"\],"stack":"Error: something\\n(.+?)","severity":"WARNING","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
     )
   })
   it('formats error object with context param', () => {
     expect(
-      format(logLevels.WARN, new Error('something'), { count: 21, val: 'bar' }),
+      format(logLevels.WARNING, new Error('something'), {
+        count: 21,
+        val: 'bar'
+      }),
       'to match',
-      /^\{"message":"something","context":\{"count":21,"val":"bar"\},"stack":"Error: something\\n(.+?)","severity":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+      /^\{"message":"something","context":\{"count":21,"val":"bar"\},"stack":"Error: something\\n(.+?)","severity":"WARNING","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
     )
   })
   it('formats error object with context and extra params', () => {
     expect(
       format(
-        logLevels.WARN,
+        logLevels.WARNING,
         new Error('something'),
         { count: 21, val: 'bar' },
         1337,
         'John'
       ),
       'to match',
-      /^\{"message":"something","context":\{"count":21,"val":"bar"\},"data":\[1337,"John"\],"stack":"Error: something\\n(.+?)","severity":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+      /^\{"message":"something","context":\{"count":21,"val":"bar"\},"data":\[1337,"John"\],"stack":"Error: something\\n(.+?)","severity":"WARNING","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
     )
   })
   it('formats context which includes error object', () => {
     expect(
-      format(logLevels.WARN, 'something', {
+      format(logLevels.WARNING, 'something', {
         MyContext: 1,
         e: new Error('some err')
       }),
       'to match',
-      /^\{"message":"something","context":\{"MyContext":1,"e":\{"stack":"Error: some err\\n(.+?)","message":"some err","__constructorName":"Error"\}\},"severity":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+      /^\{"message":"something","context":\{"MyContext":1,"e":\{"stack":"Error: some err\\n(.+?)","message":"some err","__constructorName":"Error"\}\},"severity":"WARNING","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
     )
   })
   it('formats very large message', () => {
@@ -177,12 +184,12 @@ describe('src/format', () => {
       msg += blob
     }
     expect(
-      format(logLevels.WARN, msg),
+      format(logLevels.WARNING, msg),
       'to match',
-      /^{"message":"Truncated: (something!){5000,}\.{3}"\,\"severity\"\:\"WARN\",\"timestamp\"\:\"2017-09-01T13:37:42\.000Z\"}$/
+      /^{"message":"Truncated: (something!){5000,}\.{3}"\,\"severity\"\:\"WARNING\",\"timestamp\"\:\"2017-09-01T13:37:42\.000Z\"}$/
     )
     expect(
-      format(logLevels.WARN, msg).length,
+      format(logLevels.WARNING, msg).length,
       'to be less than or equal to',
       110 * 1024
     )
@@ -197,19 +204,19 @@ describe('src/format', () => {
       data += blob
     }
     expect(
-      format(logLevels.WARN, 'hello', data),
+      format(logLevels.WARNING, 'hello', data),
       'to match',
       /^\{"message":"Truncated \{\\\"message\\\":\\\"hello\\\",\\\"data\\\":\[\\\"(something!){5000,}so.*$/
     )
     expect(
-      format(logLevels.WARN, 'hello', data).length,
+      format(logLevels.WARNING, 'hello', data).length,
       'to be less than or equal to',
       110 * 1024
     )
   })
   it('formats not too deep object', () => {
     expect(
-      format(logLevels.WARN, {
+      format(logLevels.WARNING, {
         nested: {
           nested: {
             nested: {
@@ -221,12 +228,12 @@ describe('src/format', () => {
         }
       }),
       'to be',
-      '{"nested":{"nested":{"nested":{"nested":{"nested":{"nested":{"nested":{"nested":{"nested":"value"}}}}}}}},"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"nested":{"nested":{"nested":{"nested":{"nested":{"nested":{"nested":{"nested":{"nested":"value"}}}}}}}},"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats too deep object', () => {
     expect(
-      format(logLevels.WARN, {
+      format(logLevels.WARNING, {
         nested: {
           nested: {
             nested: {
@@ -246,7 +253,7 @@ describe('src/format', () => {
         }
       }),
       'to be',
-      '{"message":"Depth limited {\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":\\"value\\"}}}}}}}}}}},\\"severity\\":\\"WARN\\",\\"timestamp\\":\\"2017-09-01T13:37:42.000Z\\"}"}'
+      '{"message":"Depth limited {\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":\\"value\\"}}}}}}}}}}},\\"severity\\":\\"WARNING\\",\\"timestamp\\":\\"2017-09-01T13:37:42.000Z\\"}"}'
     )
   })
 
@@ -257,9 +264,9 @@ describe('src/format', () => {
     topLevel.circular = topLevel
 
     expect(
-      format(logLevels.WARN, topLevel),
+      format(logLevels.WARNING, topLevel),
       'to be',
-      '{"normalProperty":"expected value","circular":{"normalProperty":"expected value","circular":"[Circular:StrippedOut]"},"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"normalProperty":"expected value","circular":{"normalProperty":"expected value","circular":"[Circular:StrippedOut]"},"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
 
@@ -285,9 +292,9 @@ describe('src/format', () => {
     }
     nestedObj.circular = nestedObj
     expect(
-      format(logLevels.WARN, nestedObj),
+      format(logLevels.WARNING, nestedObj),
       'to be',
-      '{"message":"Depth limited {\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":\\"value\\"}}}}}}}}}}},\\"circular\\":{\\"nested\\":\\"[Circular:StrippedOut]\\",\\"circular\\":\\"[Circular:StrippedOut]\\"},\\"severity\\":\\"WARN\\",\\"timestamp\\":\\"2017-09-01T13:37:42.000Z\\"}"}'
+      '{"message":"Depth limited {\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":\\"value\\"}}}}}}}}}}},\\"circular\\":{\\"nested\\":\\"[Circular:StrippedOut]\\",\\"circular\\":\\"[Circular:StrippedOut]\\"},\\"severity\\":\\"WARNING\\",\\"timestamp\\":\\"2017-09-01T13:37:42.000Z\\"}"}'
     )
   })
 
@@ -304,9 +311,13 @@ describe('src/format', () => {
     obj.message = msg
     obj.circular = obj
 
-    expect(format(logLevels.WARN, obj), 'to match', /^.*Truncated.*circular.*$/)
     expect(
-      format(logLevels.WARN, msg).length,
+      format(logLevels.WARNING, obj),
+      'to match',
+      /^.*Truncated.*circular.*$/
+    )
+    expect(
+      format(logLevels.WARNING, msg).length,
       'to be less than or equal to',
       110 * 1024
     )
@@ -318,7 +329,7 @@ describe('src/format', () => {
     sandbox.stub(JSON, 'stringify').throws()
 
     expect(() => {
-      format(logLevels.WARN, { data: 'fake' })
+      format(logLevels.WARNING, { data: 'fake' })
     }, 'to throw')
 
     sandbox.restore()
@@ -393,8 +404,8 @@ describe('src/format', () => {
           WHERE (userId = :userId) ''}
         ) AS count2
     `
-    const expectedLogOutput = `{"message":"\\n      SELECT\\n        ( SELECT COUNT(*) FROM messages\\n          WHERE (senderId = :userId OR receiverId = :userId) AND workshopId = :workshopId\\n        ) AS count1,\\n\\n        ( SELECT COUNT(*) FROM UserActivities\\n          WHERE (userId = :userId) ''}\\n        ) AS count2\\n    ","severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}`
+    const expectedLogOutput = `{"message":"\\n      SELECT\\n        ( SELECT COUNT(*) FROM messages\\n          WHERE (senderId = :userId OR receiverId = :userId) AND workshopId = :workshopId\\n        ) AS count1,\\n\\n        ( SELECT COUNT(*) FROM UserActivities\\n          WHERE (userId = :userId) ''}\\n        ) AS count2\\n    ","severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}`
 
-    expect(format(logLevels.WARN, countQuery), 'to be', expectedLogOutput)
+    expect(format(logLevels.WARNING, countQuery), 'to be', expectedLogOutput)
   })
 })

--- a/src/format.test.js
+++ b/src/format.test.js
@@ -13,42 +13,42 @@ describe('src/format', () => {
 
   it('formats string message', () => {
     expect(
-      format(logLevels.WARNING, 'something'),
+      format(logLevels.WARN, 'something'),
       'to be',
       '{"message":"something","severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats number message', () => {
     expect(
-      format(logLevels.WARNING, 42),
+      format(logLevels.WARN, 42),
       'to be',
       '{"message":42,"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats string message with extra params', () => {
     expect(
-      format(logLevels.WARNING, 'something', 42, 'foo'),
+      format(logLevels.WARN, 'something', 42, 'foo'),
       'to be',
       '{"message":"something","data":[42,"foo"],"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats string message with context param', () => {
     expect(
-      format(logLevels.WARNING, 'something', { count: 42, val: 'foo' }),
+      format(logLevels.WARN, 'something', { count: 42, val: 'foo' }),
       'to be',
       '{"message":"something","context":{"count":42,"val":"foo"},"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats string message with context and extra params', () => {
     expect(
-      format(logLevels.WARNING, 'something', { count: 42, val: 'foo' }, 'foo'),
+      format(logLevels.WARN, 'something', { count: 42, val: 'foo' }, 'foo'),
       'to be',
       '{"message":"something","context":{"count":42,"val":"foo"},"data":["foo"],"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats single object', () => {
     expect(
-      format(logLevels.WARNING, {
+      format(logLevels.WARN, {
         message: 'something',
         count: 42,
         val: 'foo'
@@ -60,7 +60,7 @@ describe('src/format', () => {
   it('formats single object with extra params', () => {
     expect(
       format(
-        logLevels.WARNING,
+        logLevels.WARN,
         { message: 'something', count: 42, val: 'foo' },
         42,
         'foo'
@@ -72,7 +72,7 @@ describe('src/format', () => {
   it('formats single object with context param', () => {
     expect(
       format(
-        logLevels.WARNING,
+        logLevels.WARN,
         { message: 'something', count: 42, val: 'foo' },
         { count: 21, val: 'bar' }
       ),
@@ -83,7 +83,7 @@ describe('src/format', () => {
   it('formats single object with context and extra params', () => {
     expect(
       format(
-        logLevels.WARNING,
+        logLevels.WARN,
         { message: 'something', count: 42, val: 'foo' },
         { count: 21, val: 'bar' },
         1337,
@@ -95,21 +95,21 @@ describe('src/format', () => {
   })
   it('formats single array', () => {
     expect(
-      format(logLevels.WARNING, ['something', 42]),
+      format(logLevels.WARN, ['something', 42]),
       'to be',
       '{"message":"something, 42","data":["something",42],"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats single array with extra params', () => {
     expect(
-      format(logLevels.WARNING, ['something', 42], 42, 'foo'),
+      format(logLevels.WARN, ['something', 42], 42, 'foo'),
       'to be',
       '{"message":"something, 42","data":["something",42,42,"foo"],"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
   it('formats single array with context param', () => {
     expect(
-      format(logLevels.WARNING, ['something', 42], { count: 21, val: 'bar' }),
+      format(logLevels.WARN, ['something', 42], { count: 21, val: 'bar' }),
       'to be',
       '{"message":"something, 42","context":{"count":21,"val":"bar"},"data":["something",42],"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
@@ -117,7 +117,7 @@ describe('src/format', () => {
   it('formats single array with context and extra params', () => {
     expect(
       format(
-        logLevels.WARNING,
+        logLevels.WARN,
         ['something', 42],
         { count: 21, val: 'bar' },
         1337,
@@ -129,21 +129,21 @@ describe('src/format', () => {
   })
   it('formats error object', () => {
     expect(
-      format(logLevels.WARNING, new Error('something')),
+      format(logLevels.WARN, new Error('something')),
       'to match',
       /^\{"message":"something","stack":"Error: something\\n(.+?)","severity":"WARNING","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
     )
   })
   it('formats error object with extra params', () => {
     expect(
-      format(logLevels.WARNING, new Error('something'), 42, 'foo'),
+      format(logLevels.WARN, new Error('something'), 42, 'foo'),
       'to match',
       /^\{"message":"something","data":\[42,"foo"\],"stack":"Error: something\\n(.+?)","severity":"WARNING","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
     )
   })
   it('formats error object with context param', () => {
     expect(
-      format(logLevels.WARNING, new Error('something'), {
+      format(logLevels.WARN, new Error('something'), {
         count: 21,
         val: 'bar'
       }),
@@ -154,7 +154,7 @@ describe('src/format', () => {
   it('formats error object with context and extra params', () => {
     expect(
       format(
-        logLevels.WARNING,
+        logLevels.WARN,
         new Error('something'),
         { count: 21, val: 'bar' },
         1337,
@@ -166,7 +166,7 @@ describe('src/format', () => {
   })
   it('formats context which includes error object', () => {
     expect(
-      format(logLevels.WARNING, 'something', {
+      format(logLevels.WARN, 'something', {
         MyContext: 1,
         e: new Error('some err')
       }),
@@ -184,12 +184,12 @@ describe('src/format', () => {
       msg += blob
     }
     expect(
-      format(logLevels.WARNING, msg),
+      format(logLevels.WARN, msg),
       'to match',
       /^{"message":"Truncated: (something!){5000,}\.{3}"\,\"severity\"\:\"WARNING\",\"timestamp\"\:\"2017-09-01T13:37:42\.000Z\"}$/
     )
     expect(
-      format(logLevels.WARNING, msg).length,
+      format(logLevels.WARN, msg).length,
       'to be less than or equal to',
       110 * 1024
     )
@@ -204,19 +204,19 @@ describe('src/format', () => {
       data += blob
     }
     expect(
-      format(logLevels.WARNING, 'hello', data),
+      format(logLevels.WARN, 'hello', data),
       'to match',
       /^\{"message":"Truncated \{\\\"message\\\":\\\"hello\\\",\\\"data\\\":\[\\\"(something!){5000,}so.*$/
     )
     expect(
-      format(logLevels.WARNING, 'hello', data).length,
+      format(logLevels.WARN, 'hello', data).length,
       'to be less than or equal to',
       110 * 1024
     )
   })
   it('formats not too deep object', () => {
     expect(
-      format(logLevels.WARNING, {
+      format(logLevels.WARN, {
         nested: {
           nested: {
             nested: {
@@ -233,7 +233,7 @@ describe('src/format', () => {
   })
   it('formats too deep object', () => {
     expect(
-      format(logLevels.WARNING, {
+      format(logLevels.WARN, {
         nested: {
           nested: {
             nested: {
@@ -264,7 +264,7 @@ describe('src/format', () => {
     topLevel.circular = topLevel
 
     expect(
-      format(logLevels.WARNING, topLevel),
+      format(logLevels.WARN, topLevel),
       'to be',
       '{"normalProperty":"expected value","circular":{"normalProperty":"expected value","circular":"[Circular:StrippedOut]"},"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
@@ -292,7 +292,7 @@ describe('src/format', () => {
     }
     nestedObj.circular = nestedObj
     expect(
-      format(logLevels.WARNING, nestedObj),
+      format(logLevels.WARN, nestedObj),
       'to be',
       '{"message":"Depth limited {\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":{\\"nested\\":\\"value\\"}}}}}}}}}}},\\"circular\\":{\\"nested\\":\\"[Circular:StrippedOut]\\",\\"circular\\":\\"[Circular:StrippedOut]\\"},\\"severity\\":\\"WARNING\\",\\"timestamp\\":\\"2017-09-01T13:37:42.000Z\\"}"}'
     )
@@ -311,13 +311,9 @@ describe('src/format', () => {
     obj.message = msg
     obj.circular = obj
 
+    expect(format(logLevels.WARN, obj), 'to match', /^.*Truncated.*circular.*$/)
     expect(
-      format(logLevels.WARNING, obj),
-      'to match',
-      /^.*Truncated.*circular.*$/
-    )
-    expect(
-      format(logLevels.WARNING, msg).length,
+      format(logLevels.WARN, msg).length,
       'to be less than or equal to',
       110 * 1024
     )
@@ -329,7 +325,7 @@ describe('src/format', () => {
     sandbox.stub(JSON, 'stringify').throws()
 
     expect(() => {
-      format(logLevels.WARNING, { data: 'fake' })
+      format(logLevels.WARN, { data: 'fake' })
     }, 'to throw')
 
     sandbox.restore()
@@ -406,6 +402,6 @@ describe('src/format', () => {
     `
     const expectedLogOutput = `{"message":"\\n      SELECT\\n        ( SELECT COUNT(*) FROM messages\\n          WHERE (senderId = :userId OR receiverId = :userId) AND workshopId = :workshopId\\n        ) AS count1,\\n\\n        ( SELECT COUNT(*) FROM UserActivities\\n          WHERE (userId = :userId) ''}\\n        ) AS count2\\n    ","severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}`
 
-    expect(format(logLevels.WARNING, countQuery), 'to be', expectedLogOutput)
+    expect(format(logLevels.WARN, countQuery), 'to be', expectedLogOutput)
   })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -4,5 +4,6 @@ module.exports = {
   info: require('./info'),
   warn: require('./warn'),
   error: require('./error'),
+  critical: require('./critical'),
   MetricRegistry: require('./metric')
 }

--- a/src/info.test.js
+++ b/src/info.test.js
@@ -12,9 +12,7 @@ describe('src/info', () => {
   })
   afterEach(() => {
     process.env.LOG_LEVEL = this.oldLogLevel
-    this.clock.restore()
-    console.warn.restore()
-    console.error.restore()
+    sinon.restore()
   })
 
   it('logs nothing', () => {

--- a/src/levels.js
+++ b/src/levels.js
@@ -1,6 +1,7 @@
 const logLevels = {
+  CRITICAL: 50,
   ERROR: 40,
-  WARN: 30,
+  WARNING: 30,
   INFO: 20,
   STATISTIC: 15,
   DEBUG: 10
@@ -12,7 +13,7 @@ const getLogLevel = () => {
   if (logLevel in logLevels) {
     return logLevels[logLevel]
   }
-  return logLevels.WARN
+  return logLevels.WARNING
 }
 
 const getLogLevelName = logLevel => {

--- a/src/levels.js
+++ b/src/levels.js
@@ -1,7 +1,7 @@
 const logLevels = {
   CRITICAL: 50,
   ERROR: 40,
-  WARNING: 30,
+  WARN: 30,
   INFO: 20,
   STATISTIC: 15,
   DEBUG: 10
@@ -13,18 +13,26 @@ const getLogLevel = () => {
   if (logLevel in logLevels) {
     return logLevels[logLevel]
   }
-  return logLevels.WARNING
+  return logLevels.WARN
 }
 
 const getLogLevelName = logLevel => {
-  let level = 'UNKNOWN'
-  for (const key in logLevels) {
-    if (logLevel === logLevels[key]) {
-      level = key
-      break
-    }
+  switch (logLevel) {
+    case logLevels.CRITICAL:
+      return 'CRITICAL'
+    case logLevels.ERROR:
+      return 'ERROR'
+    case logLevels.WARN:
+      return 'WARNING' // Override for stackdriver severity
+    case logLevels.INFO:
+      return 'INFO'
+    case logLevels.STATISTIC:
+      return 'STATISTIC'
+    case logLevels.DEBUG:
+      return 'DEBUG'
+    default:
+      return 'UNKNOWN'
   }
-  return level
 }
 
 module.exports = {

--- a/src/levels.test.js
+++ b/src/levels.test.js
@@ -12,11 +12,11 @@ describe('src/levels', () => {
     })
 
     it('defaults to WARN', () => {
-      expect(getLogLevel(), 'to be', logLevels.WARN)
+      expect(getLogLevel(), 'to be', logLevels.WARNING)
     })
     it('defaults to WARN for empty string', () => {
       process.env.LOG_LEVEL = ''
-      expect(getLogLevel(), 'to be', logLevels.WARN)
+      expect(getLogLevel(), 'to be', logLevels.WARNING)
     })
     it('has environment set to DEBUG', () => {
       process.env.LOG_LEVEL = 'DEBUG'
@@ -32,7 +32,7 @@ describe('src/levels', () => {
     })
     it('has environment set to WARN', () => {
       process.env.LOG_LEVEL = 'WARN'
-      expect(getLogLevel(), 'to be', logLevels.WARN)
+      expect(getLogLevel(), 'to be', logLevels.WARNING)
     })
     it('has environment set to ERROR', () => {
       process.env.LOG_LEVEL = 'ERROR'
@@ -44,7 +44,7 @@ describe('src/levels', () => {
     })
     it('has environment set to mixed case', () => {
       process.env.LOG_LEVEL = 'Warn'
-      expect(getLogLevel(), 'to be', logLevels.WARN)
+      expect(getLogLevel(), 'to be', logLevels.WARNING)
     })
   })
   describe('getLogLevelName', () => {
@@ -52,7 +52,7 @@ describe('src/levels', () => {
       expect(getLogLevelName(40), 'to be', 'ERROR')
     })
     it('gets WARN', () => {
-      expect(getLogLevelName(30), 'to be', 'WARN')
+      expect(getLogLevelName(30), 'to be', 'WARNING')
     })
     it('gets INFO', () => {
       expect(getLogLevelName(20), 'to be', 'INFO')

--- a/src/levels.test.js
+++ b/src/levels.test.js
@@ -12,11 +12,11 @@ describe('src/levels', () => {
     })
 
     it('defaults to WARN', () => {
-      expect(getLogLevel(), 'to be', logLevels.WARNING)
+      expect(getLogLevel(), 'to be', logLevels.WARN)
     })
     it('defaults to WARN for empty string', () => {
       process.env.LOG_LEVEL = ''
-      expect(getLogLevel(), 'to be', logLevels.WARNING)
+      expect(getLogLevel(), 'to be', logLevels.WARN)
     })
     it('has environment set to DEBUG', () => {
       process.env.LOG_LEVEL = 'DEBUG'
@@ -32,11 +32,15 @@ describe('src/levels', () => {
     })
     it('has environment set to WARN', () => {
       process.env.LOG_LEVEL = 'WARN'
-      expect(getLogLevel(), 'to be', logLevels.WARNING)
+      expect(getLogLevel(), 'to be', logLevels.WARN)
     })
     it('has environment set to ERROR', () => {
       process.env.LOG_LEVEL = 'ERROR'
       expect(getLogLevel(), 'to be', logLevels.ERROR)
+    })
+    it('has environment set to CRITICAL', () => {
+      process.env.LOG_LEVEL = 'CRITICAL'
+      expect(getLogLevel(), 'to be', logLevels.CRITICAL)
     })
     it('has environment set to lowercase', () => {
       process.env.LOG_LEVEL = 'error'
@@ -44,10 +48,13 @@ describe('src/levels', () => {
     })
     it('has environment set to mixed case', () => {
       process.env.LOG_LEVEL = 'Warn'
-      expect(getLogLevel(), 'to be', logLevels.WARNING)
+      expect(getLogLevel(), 'to be', logLevels.WARN)
     })
   })
   describe('getLogLevelName', () => {
+    it('gets CRITICAL', () => {
+      expect(getLogLevelName(50), 'to be', 'CRITICAL')
+    })
     it('gets ERROR', () => {
       expect(getLogLevelName(40), 'to be', 'ERROR')
     })

--- a/src/log.js
+++ b/src/log.js
@@ -8,7 +8,7 @@ const doLog = (level, ...args) => {
     case logLevels.ERROR:
       console.error(output)
       break
-    case logLevels.WARNING:
+    case logLevels.WARN:
       console.warn(output)
       break
     default:

--- a/src/log.js
+++ b/src/log.js
@@ -4,10 +4,11 @@ const { format } = require('./format')
 const doLog = (level, ...args) => {
   const output = format(level, ...args)
   switch (level) {
+    case logLevels.CRITICAL:
     case logLevels.ERROR:
       console.error(output)
       break
-    case logLevels.WARN:
+    case logLevels.WARNING:
       console.warn(output)
       break
     default:

--- a/src/metric.test.js
+++ b/src/metric.test.js
@@ -12,9 +12,7 @@ describe('src/metric.js', () => {
     this.statistic = sinon.spy(console, 'log')
   })
   afterEach(async () => {
-    this.clock.restore()
-    this.createKey.restore()
-    this.statistic.restore()
+    sinon.restore()
   })
 
   it('creates cumulative metrics', async () => {

--- a/src/statistic.test.js
+++ b/src/statistic.test.js
@@ -12,9 +12,7 @@ describe('src/statistic', () => {
   })
   afterEach(() => {
     process.env.LOG_LEVEL = this.oldLogLevel
-    this.clock.restore()
-    console.warn.restore()
-    console.error.restore()
+    sinon.restore()
   })
 
   it('logs nothing', () => {

--- a/src/warn.js
+++ b/src/warn.js
@@ -2,5 +2,5 @@ const { logLevels } = require('./levels')
 const log = require('./log')
 
 module.exports = (...args) => {
-  return log(logLevels.WARNING, ...args)
+  return log(logLevels.WARN, ...args)
 }

--- a/src/warn.test.js
+++ b/src/warn.test.js
@@ -31,7 +31,7 @@ describe('src/warn', () => {
     expect(console.log.callCount, 'to be', 0)
     expect(console.warn.callCount, 'to be', 1)
     expect(console.warn.args[0], 'to equal', [
-      '{"message":"something","severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.error.callCount, 'to be', 0)
   })
@@ -40,7 +40,7 @@ describe('src/warn', () => {
     expect(console.log.callCount, 'to be', 0)
     expect(console.warn.callCount, 'to be', 1)
     expect(console.warn.args[0], 'to equal', [
-      '{"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.error.callCount, 'to be', 0)
   })
@@ -50,7 +50,7 @@ describe('src/warn', () => {
     expect(console.log.callCount, 'to be', 0)
     expect(console.warn.callCount, 'to be', 1)
     expect(console.warn.args[0], 'to equal', [
-      '{"message":"something","data":[42,{"foo":"bar"}],"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","data":[42,{"foo":"bar"}],"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.error.callCount, 'to be', 0)
   })
@@ -62,13 +62,13 @@ describe('src/warn', () => {
     expect(console.log.callCount, 'to be', 0)
     expect(console.warn.callCount, 'to be', 3)
     expect(console.warn.args[0], 'to equal', [
-      '{"message":"something","severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.warn.args[1], 'to equal', [
-      '{"message":"something else","data":[42],"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something else","data":[42],"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.warn.args[2], 'to equal', [
-      '{"foo":true,"severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"foo":true,"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     ])
     expect(console.error.callCount, 'to be', 0)
   })
@@ -106,7 +106,7 @@ describe('src/warn', () => {
         expect(console.log.callCount, 'to be', 0)
         expect(console.warn.callCount, 'to be', 1)
         expect(console.warn.args[0], 'to equal', [
-          '{"message":"something","severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+          '{"message":"something","severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
         ])
         expect(console.error.callCount, 'to be', 0)
         done()
@@ -121,7 +121,7 @@ describe('src/warn', () => {
         expect(console.log.callCount, 'to be', 0)
         expect(console.warn.callCount, 'to be', 1)
         expect(console.warn.args[0], 'to equal', [
-          '{"message":"something","severity":"WARN","timestamp":"2017-09-01T13:37:42.000Z"}'
+          '{"message":"something","severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
         ])
         expect(console.error.callCount, 'to be', 0)
         done()
@@ -141,7 +141,7 @@ describe('src/warn', () => {
         expect(
           console.warn.args[0][0],
           'to match',
-          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","severity":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","severity":"WARNING","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
         )
         expect(console.error.callCount, 'to be', 0)
         done()
@@ -162,7 +162,7 @@ describe('src/warn', () => {
         expect(
           console.warn.args[0][0],
           'to match',
-          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","severity":"WARN","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
+          /^\{"message":"wrah","stack":"Error: wrah\\n(.+?)","severity":"WARNING","timestamp":"2017-09-01T13:37:42\.000Z"\}$/
         )
         expect(console.error.callCount, 'to be', 0)
         done()

--- a/src/warn.test.js
+++ b/src/warn.test.js
@@ -13,10 +13,7 @@ describe('src/warn', () => {
   })
   afterEach(() => {
     process.env.LOG_LEVEL = this.oldLogLevel
-    this.clock.restore()
-    console.log.restore()
-    console.warn.restore()
-    console.error.restore()
+    sinon.restore()
   })
 
   it('logs nothing', () => {


### PR DESCRIPTION
log.warn now properly outputs severity:WARNING as per stackdriver: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity

Part of: https://github.com/connectedcars/api/issues/1625

