### PR TITLE
Updates type to require strings as labels

### DIFF
--- a/types/@connectedcars/logutil/index.d.ts
+++ b/types/@connectedcars/logutil/index.d.ts
@@ -6,7 +6,7 @@ export function error(...args: any[]): void
 export function critical(...args: any[]): void
 
 export class MetricRegistry {
-  public gauge(name: string, value: number, labels?: object): Promise<void>
-  cumulative(name: string, value: number, labels?: object): Promise<void>
+  public gauge(name: string, value: number, labels?: { [key: string]: string }): Promise<void>
+  cumulative(name: string, value: number, labels?: { [key: string]: string }): Promise<void>
   logMetrics(): Promise<void>
 }


### PR DESCRIPTION
Google custom metrics only allows strings as labels.