### PR TITLE
Skips metric data older than 24 hours

### DIFF
--- a/src/metric.js
+++ b/src/metric.js
@@ -19,9 +19,16 @@ class MetricRegistry {
   }
   async logMetrics() {
     const metrics = await this.getMetrics()
-
+    const result = []
+    for (const metric of metrics) {
+      if (Date.now() - metric.endTime > 24 * 60 * 60 * 1000) {
+        // Skip data points more than 24 hours old
+        continue
+      }
+      result.push(this.convertTimestampToIsoString(metric))
+    }
     statistic(`Metric dump`, {
-      metrics: metrics.map(this.convertTimestampToIsoString)
+      metrics: result
     })
   }
   async getMetrics() {


### PR DESCRIPTION
If we log old metrics from the services, the metrics subscriber API will skip the entire batch. This makes sure we instead just skip the specific data point. Perhaps we want to just change the `endTime` to something like `Math.max(endTime, Date.now() - 24 * 60 * 60 * 1000)`. What do you think, @chribsen?

Fixes https://app.clubhouse.io/connectedcars/story/14350/add-24-hour-limit-to-metrics-in-logutil [ch14350]