### PR TITLE
Remove unused assignment of empty array

### DIFF
--- a/src/metric.js
+++ b/src/metric.js
@@ -54,7 +54,6 @@ class MetricRegistry {
       metric.endTime = metric.endTime ? metric.endTime : Date.now()
 
       if (metric.reducerFn) {
-        this.metrics[key].value = []
         metric.value = metric.reducerFn(metric.value)
       }
 


### PR DESCRIPTION
It should have no impact removing it, as the metrics array is
being cleared in logMetrics. Also, the function should not modify
the state.