### PR TITLE
refactor(MetricRegistry): emit metric dumps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@connectedcars/setup": "^0.18.0",
         "@connectedcars/test": "^0.22.9",
         "@types/jest": "29.2.5",
+        "@types/node": "^20.14.10",
         "@typescript-eslint/eslint-plugin": "5.48.0",
         "@typescript-eslint/parser": "5.48.0",
         "babel-jest": "29.3.1",
@@ -34,7 +35,7 @@
         "typescript": "4.9.4"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3206,10 +3207,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.0.tgz",
-      "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==",
-      "dev": true
+      "version": "20.14.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -8979,6 +8983,12 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -11522,10 +11532,13 @@
       }
     },
     "@types/node": {
-      "version": "18.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.0.tgz",
-      "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==",
-      "dev": true
+      "version": "20.14.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/prettier": {
       "version": "2.7.2",
@@ -15740,6 +15753,12 @@
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
       "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple log formatting for Node",
   "main": "build/dist/src/index.js",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "test": "TZ=UTC jest",
@@ -46,6 +46,7 @@
     "@connectedcars/setup": "^0.18.0",
     "@connectedcars/test": "^0.22.9",
     "@types/jest": "29.2.5",
+    "@types/node": "^20.14.10",
     "@typescript-eslint/eslint-plugin": "5.48.0",
     "@typescript-eslint/parser": "5.48.0",
     "babel-jest": "29.3.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { critical } from './critical'
 import { debug } from './debug'
 import { error } from './error'
 import { info } from './info'
-import { clearMetricRegistry, getMetricRegistry, MetricRegistry } from './metric'
+import { clearMetricRegistry, getMetricRegistry, MetricRegistry, MetricType } from './metric'
 import { notice } from './notice'
 import { statistic } from './statistic'
 import { trace } from './trace'
@@ -21,6 +21,8 @@ export {
   trace,
   warn
 }
+
+export type { MetricType }
 
 // eslint-disable-next-line no-restricted-syntax
 export default {

--- a/src/metric.test.ts
+++ b/src/metric.test.ts
@@ -554,6 +554,93 @@ describe('src/metric.js', () => {
       )
     })
 
+    it('emits metrics', () => {
+      // Add an event listener to the metricRegistry
+      const dumpedMetrics: any[] = []
+      metricRegistry.on('foo-metric', metricDump => {
+        dumpedMetrics.push(...metricDump.metrics)
+      })
+      metricRegistry.on('bar-metric', metricDump => {
+        dumpedMetrics.push(...metricDump.metrics)
+      })
+
+      metricRegistry.gauge('foo-metric', 4, { brand: 'vw' })
+      metricRegistry.gauge('foo-metric', 2, { brand: 'seat' })
+      metricRegistry.gauge('bar-metric', 20, { brand: 'vw' })
+      metricRegistry.logMetrics()
+
+      expect(logStub.callCount).toEqual(2)
+      expect(logStub.args[0].length).toEqual(1)
+      expect(logStub.args[0][0]).toEqual(
+        JSON.stringify({
+          message: 'Metric dump',
+          context: {
+            metrics: [
+              {
+                name: 'foo-metric',
+                type: 'GAUGE',
+                value: 4,
+                labels: { brand: 'vw' },
+                endTime: '2017-09-01T13:37:42.000Z'
+              },
+              {
+                name: 'foo-metric',
+                type: 'GAUGE',
+                value: 2,
+                labels: { brand: 'seat' },
+                endTime: '2017-09-01T13:37:42.000Z'
+              }
+            ]
+          },
+          severity: 'STATISTIC',
+          timestamp: '2017-09-01T13:37:42.000Z'
+        })
+      )
+
+      expect(logStub.args[1][0]).toEqual(
+        JSON.stringify({
+          message: 'Metric dump',
+          context: {
+            metrics: [
+              {
+                name: 'bar-metric',
+                type: 'GAUGE',
+                value: 20,
+                labels: { brand: 'vw' },
+                endTime: '2017-09-01T13:37:42.000Z'
+              }
+            ]
+          },
+          severity: 'STATISTIC',
+          timestamp: '2017-09-01T13:37:42.000Z'
+        })
+      )
+
+      expect(dumpedMetrics).toEqual([
+        {
+          name: 'foo-metric',
+          type: 'GAUGE',
+          value: 4,
+          labels: { brand: 'vw' },
+          endTime: '2017-09-01T13:37:42.000Z'
+        },
+        {
+          name: 'foo-metric',
+          type: 'GAUGE',
+          value: 2,
+          labels: { brand: 'seat' },
+          endTime: '2017-09-01T13:37:42.000Z'
+        },
+        {
+          name: 'bar-metric',
+          type: 'GAUGE',
+          value: 20,
+          labels: { brand: 'vw' },
+          endTime: '2017-09-01T13:37:42.000Z'
+        }
+      ])
+    })
+
     it('cumulative handles name collision', () => {
       metricRegistry.gauge('foo-metric', 4, { brand: 'vw' })
       metricRegistry.cumulative('foo-metric', 20, { brand: 'vw' })


### PR DESCRIPTION
[sc-114464][skip-sc]

https://app.shortcut.com/connectedcars/story/114464/health-check-thresholds-on-kubernetes-probes-should-be-automatically-resolved-based-on-cars-units-in-the-region#activity-117208

## Notes:
- The usage is exemplified in the test but the idea here is that we want to listen to a specific metric being dumped and allow to perform actions based on that. On services like f.x mailman, we can listen to the specific dumped metrics and choose how to add them to the database