### PR TITLE
fix(Format): format the trace in logs correctly

### DIFF
--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -346,7 +346,7 @@ describe('src/format', () => {
       otherUselessField: 'useless'
     })
     expect(output).toEqual(
-      '{"message":"something","context":{"otherUselessField":"useless"},"trace":"bf681a55eda601982a09d5fc777320a9","spanId":"5909853980582992892","traceSampled":false,"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
+      '{"message":"something","context":{"otherUselessField":"useless"},"logging.googleapis.com/trace":"bf681a55eda601982a09d5fc777320a9","logging.googleapis.com/spanId":"5909853980582992892","logging.googleapis.com/trace_sampled":false,"severity":"WARNING","timestamp":"2017-09-01T13:37:42.000Z"}'
     )
   })
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -3,6 +3,11 @@ import { getLogLevelName } from './levels'
 const MAX_NESTED_DEPTH = 10
 const MAX_TEXT_LENGTH = 70 * 1024
 
+//https://github.com/googleapis/nodejs-logging/blob/9d1d480406c4d1526c8a7fafd9b18379c0c7fcea/src/entry.ts#L45-L47
+export const SPAN_ID_KEY = 'logging.googleapis.com/spanId'
+export const TRACE_KEY = 'logging.googleapis.com/trace'
+export const TRACE_SAMPLED_KEY = 'logging.googleapis.com/trace_sampled'
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function reachedMaxDepth(obj: any, level = 0): boolean {
   for (const key in obj) {
@@ -97,9 +102,9 @@ export function format(level: number, ...args: unknown[]): string {
           // Try to find trace info from context
           // Based on field in LogEntry: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#FIELDS.trace_sampled
           if (output.context['spanId'] && output.context['trace']) {
-            output.trace = output.context['trace']
-            output.spanId = output.context['spanId']
-            output.traceSampled = output.context['traceSampled'] ?? false
+            output[TRACE_KEY] = output.context['trace']
+            output[SPAN_ID_KEY] = output.context['spanId']
+            output[TRACE_SAMPLED_KEY] = output.context['traceSampled'] ?? false
             // We don't need these fields in the context
             delete output.context['spanId']
             delete output.context['trace']


### PR DESCRIPTION
[sc-123350][skip-sc]

With this we should be able to see the trace info on the API (and services that include these fields in the context): 
<img width="676" height="509" alt="image" src="https://github.com/user-attachments/assets/e5006fb5-7ce5-4998-9242-b5888619c22d" />
One step closer to matching the load balancer request to the api request